### PR TITLE
feat: add image support

### DIFF
--- a/minerva/format_chat_history_for_openai.py
+++ b/minerva/format_chat_history_for_openai.py
@@ -1,0 +1,26 @@
+from minerva.message_history import ContentType, ImageContent, MessageHistory
+from minerva.tool_utils import TOOL_PREFIX
+
+
+def format_chat_history_for_openai(system_prompt: str, chat_history: MessageHistory):
+  messages = [{"role": "system", "content": system_prompt}]
+  for message in chat_history.history:
+    content: ContentType = None
+    if isinstance(message.content, str):
+      content = [{"type": "text", "text": message.content}]
+    elif isinstance(message.content, ImageContent):
+      content = []
+      for image in message.content.images:
+        content.append({
+            "type": "image_url",
+            "image_url": {"url": image.url},
+        })
+      if message.content.text:
+        content.append({"type": "text", "text": message.content.text})
+
+    messages.append({
+        "role": "system" if message.author.startswith(TOOL_PREFIX) else "user",
+        "content": content,
+        "name": message.author,
+    })
+  return messages

--- a/minerva/get_image_from_telegram_photo.py
+++ b/minerva/get_image_from_telegram_photo.py
@@ -1,0 +1,17 @@
+import base64
+from telegram import Bot, Message as PhotoSize
+
+from minerva.message_history import Image
+
+
+async def get_image_from_telegram_photo(bot: Bot, photo: list[PhotoSize]) -> Image:
+  sorted_photo_sizes = sorted(photo, key=lambda p: p.width)
+  largest_photo_size = sorted_photo_sizes[-1]
+  photo_object = await bot.get_file(largest_photo_size.file_id)
+  photo_bytes = await photo_object.download_as_bytearray()
+  photo_base64 = f"data:image/jpeg;base64,{base64.b64encode(photo_bytes).decode("utf-8")}"
+  return Image(
+      url=photo_base64,
+      height_px=largest_photo_size.height,
+      width_px=largest_photo_size.width,
+  )

--- a/minerva/prompt.py
+++ b/minerva/prompt.py
@@ -1,8 +1,6 @@
 from typing import NamedTuple
 from enum import StrEnum
-from minerva.message_history import MessageHistory
 from minerva.tool_utils import format_tool, format_tool_username
-from datetime import datetime, timezone
 
 USERNAMELESS_ID_PREFIX = "id-"
 ACTION_PREFIX = "Action:"
@@ -117,13 +115,6 @@ class Prompt:
       tools: dict[str, callable],
   ):
     self.prompt = get_base_prompt(ai_name, ai_username, tools)
-
-  def format(self, message_history: MessageHistory) -> str:
-    return (
-        f"{self.prompt}\n\n"
-        f"Current datetime in UTC is {datetime.now().astimezone(timezone.utc)}\n\n"
-        f"CONVERSATION HISTORY:\n\n{message_history}"
-    )
 
   def __str__(self):
     return self.prompt

--- a/minerva/tool_utils.py
+++ b/minerva/tool_utils.py
@@ -3,6 +3,9 @@ from typing import NamedTuple
 import pyparsing as pp
 
 
+TOOL_PREFIX = "TOOL-"
+
+
 def format_tool(name: str, tool: callable) -> str:
   return f"""Name: {name}
 Signature: {signature(tool)}
@@ -62,4 +65,4 @@ def parse_tool_call(message: str, tools: dict[str, callable]) -> ToolCall:
 
 
 def format_tool_username(tool_name: str) -> str:
-  return f"TOOL-{tool_name}"
+  return f"{TOOL_PREFIX}{tool_name}"


### PR DESCRIPTION
## How does this PR impact the user?

Users can start sending image messages to the bot.

## Description

- [x] switch from putting the whole chat history into the system prompt to putting it into the `messages` API field
- [x] update the `Message` and the `MessageHistory` to support images
- [x] add `format_chat_history_for_openai` helper
- [x] add `get_image_from_telegram_photo`
- [x] add support for image messages

## Limitations

- if Minerva is tagged in the image caption it doesn't see it
- Minerva treats multiple photos sent in a single message as multiple messages

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
