### PR TITLE
chore: relax Python requirements to let Ubuntu users run Minerva without having to update their Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "~3.12.5"
+python = "~3.12.3"
 openai = "^1.43.0"
 python-dotenv = "^1.0.1"
 tiktoken = "^0.7.0"


### PR DESCRIPTION
## How does this PR impact the developer?

This PR allows to use standart python Ubuntu version 3.12.3 instead of 3.12.5

## Description

I only rewrite a python version in pyproject.toml