### PR TITLE
fix: Minerva should "reply to" messages addressed to it + remove unneeded `business_connection_id` param

### DIFF
--- a/minerva/minerva.py
+++ b/minerva/minerva.py
@@ -180,7 +180,7 @@ class Minerva:
 
     await chat_session.create_response(
       user_id=f"telegram-{message.from_user.id}",
-      bussiness_connection_id=message.business_connection_id,
+      reply_to_message_id=message.id,
     )
 
   def _get_topic_id(self, message: TelegramMessage) -> int:


### PR DESCRIPTION
## How does this PR impact the user?

Minerva will be using the "reply to" feature when replying to messages.

## Description

- [x] introduce the `message_reply_to_id` param to the `ChatSession.create_response`
- [x] delete the unneeded `business_connection_id` param from the `ChatSession.create_response`

## Limitations

n/a

## Checklist

- [x] my PR is focused and contains one holistic change
- [ ] I have added screenshots or screen recordings to show the changes
